### PR TITLE
Put time dividers between room moves

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
         <h3>Breakfast</h3>
         <p><time>8:30</time></p>
       </li>
-      <li class="time hour_9_30">
+      <li class="time hour_9">
         <h3>9:30</h3>
       </li>
       <li class="session">
@@ -62,7 +62,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_10_30">
+      <li class="time hour_10">
         <h3>10:30</h3>
       </li>
       <li class="session">
@@ -92,7 +92,7 @@
         <h3>Coffee break by etecture, ordering system by Twilio</h3>
         <p><time>11:00</time></p>
       </li>
-      <li class="time hour_11_15">
+      <li class="time hour_11">
         <h3>11:15</h3>
       </li>
       <li class="session">
@@ -121,7 +121,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_11_45">
+      <li class="time hour_11">
         <h3>11:45</h3>
       </li>
       <li class="session">
@@ -155,7 +155,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_12_15">
+      <li class="time hour_12">
         <h3>12:15</h3>
       </li>
       <li class="session">
@@ -176,14 +176,14 @@
           </div>
         </a>
       </li>
-      <li class="time hour_12_45">
+      <li class="time hour_12">
         <h3>12:45</h3>
       </li>
       <li class="session">
         <h3>Lunch</h3>
         <p><time>12:45</time></p>
       </li>
-      <li class="time hour_13_45">
+      <li class="time hour_13">
         <h3>13:45</h3>
       </li>
       <li class="session">
@@ -206,7 +206,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_14_15">
+      <li class="time hour_14">
         <h3>14:15</h3>
       </li>
       <li class="session">
@@ -231,7 +231,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_14_45">
+      <li class="time hour_14">
         <h3>14:45</h3>
       </li>
       <li class="session">
@@ -256,14 +256,14 @@
           </div>
         </a>
       </li>
-      <li class="time hour_15_15">
+      <li class="time hour_15">
         <h3>15:15</h3>
       </li>
       <li class="session">
         <h3>Coffee break by etecture, ordering system by Twilio</h3>
         <p><time>15:15</time></p>
       </li>
-      <li class="time hour_15_30">
+      <li class="time hour_15">
         <h3>15:30</h3>
       </li>
       <li class="session">
@@ -315,7 +315,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_16_30">
+      <li class="time hour_16">
         <h3>16:30</h3>
       </li>
       <li class="session">
@@ -343,7 +343,7 @@
         <h3>Coffee break by etecture, ordering system by Twilio</h3>
         <p><time>17:00</time></p>
       </li>
-      <li class="time hour_17_15">
+      <li class="time hour_17">
         <h3>17:15</h3>
       </li>
       <li class="session">
@@ -370,7 +370,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_17_45">
+      <li class="time hour_17">
         <h3>17:45</h3>
       </li>
       <li class="session">
@@ -397,7 +397,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_18_15">
+      <li class="time hour_18">
         <h3>18:15</h3>
       </li>
       <li class="session">
@@ -413,7 +413,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_18_45">
+      <li class="time hour_18">
         <h3>18:45</h3>
       </li>
       <li class="session">
@@ -456,7 +456,7 @@
         <h3>Breakfast</h3>
         <p><time>9:00</time></p>
       </li>
-      <li class="time hour_17_15">
+      <li class="time hour_17">
         <h3>9:30</h3>
       </li>
       <li class="session">
@@ -496,7 +496,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_10_30">
+      <li class="time hour_10">
         <h3>10:30</h3>
       </li>
       <li class="session">
@@ -544,14 +544,14 @@
           </div>
         </a>
       </li>
-      <li class="time hour_11_30">
+      <li class="time hour_11">
         <h3>11:30</h3>
       </li>
       <li class="session">
         <h3>Coffee break by etecture, ordering system by Twilio</h3>
         <p><time>11:30</time></p>
       </li>
-      <li class="time hour_11_45">
+      <li class="time hour_11">
         <h3>11:45</h3>
       </li>
       <li class="session">
@@ -574,7 +574,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_12_15">
+      <li class="time hour_12">
         <h3>12:15</h3>
       </li>
       <li class="session">
@@ -599,7 +599,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_12_45">
+      <li class="time hour_12">
         <h3>12:25</h3>
       </li>
       <li class="session">
@@ -622,14 +622,14 @@
           </div>
         </a>
       </li>
-      <li class="time hour_13_15">
+      <li class="time hour_13">
         <h3>13:15</h3>
       </li>
       <li class="session">
         <h3>Lunch</h3>
         <p><time>13:15</time></p>
       </li>
-      <li class="time hour_14_15">
+      <li class="time hour_14">
         <h3>14:15</h3>
       </li>
       <li class="session">
@@ -652,7 +652,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_14_45">
+      <li class="time hour_14">
         <h3>14:45</h3>
       </li>
       <li class="session">
@@ -683,7 +683,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_15_15">
+      <li class="time hour_15">
         <h3>15:15</h3>
       </li>
       <li class="session">
@@ -710,7 +710,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_15_45">
+      <li class="time hour_15">
         <h3>15:45</h3>
       </li>
       <li class="session">
@@ -742,7 +742,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_16_30">
+      <li class="time hour_16">
         <h3>16:30</h3>
       </li>
       <li class="session">
@@ -774,7 +774,7 @@
         <h3>Break</h3>
         <p><time>17:00</time></p>
       </li>
-      <li class="time hour_17_15">
+      <li class="time hour_17">
         <h3>17:15</h3>
       </li>
       <li class="session">
@@ -805,7 +805,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_17_45">
+      <li class="time hour_17">
         <h3>17:45</h3>
       </li>
       <li class="session">
@@ -842,7 +842,7 @@
           </div>
         </a>
       </li>
-      <li class="time hour_18_15">
+      <li class="time hour_18">
         <h3>18:15</h3>
       </li>
       <li class="session">
@@ -856,14 +856,14 @@
           </div>
         </a>
       </li>
-      <li class="time hour_18_45">
+      <li class="time hour_18">
         <h3>18:45</h3>
       </li>
       <li class="session">
         <h3>Closing Conference, Instructions for Party, Group Photo</h3>
         <p><time>18:45</time></p>
       </li>
-      <li class="time hour_19_30">
+      <li class="time hour_19">
         <h3>19:30</h3>
       </li>
       <li class="session">


### PR DESCRIPTION
Instead of putting time dividers at the hour, put the time dividers between room moves. This will make it easy to scan and see when the next room change is, and will make it clear which talks are happening at the same time.
